### PR TITLE
feat: Implement login and register pages (Issue #41)

### DIFF
--- a/src/web/app/articles/[id]/page.tsx
+++ b/src/web/app/articles/[id]/page.tsx
@@ -118,10 +118,10 @@ export default function ArticleDetailPage() {
   // Handle vocabulary deletion
   const handleDeleteVocabulary = async (vocabId: string) => {
     try {
-      const response = await fetch(`/api/dictionary/vocabularies/${vocabId}`, {
+      const response = await fetchWithAuth(`/api/dictionary/vocabularies/${vocabId}`, {
         method: 'DELETE'
       })
-      
+
       if (response.ok) {
         setVocabularies(prev => prev.filter(v => v.id !== vocabId))
       }
@@ -147,8 +147,8 @@ export default function ArticleDetailPage() {
       if (!currentJobId) {
         return
       }
-      
-      fetch(`/api/status?job_id=${currentJobId}`)
+
+      fetchWithAuth(`/api/status?job_id=${currentJobId}`)
         .then(res => res.json())
         .then(data => {
           // Only update progress if it actually changed
@@ -174,13 +174,13 @@ export default function ArticleDetailPage() {
             // Reload article metadata and content
             const fetchArticle = async () => {
               try {
-                const metadataResponse = await fetch(`/api/articles/${articleId}`)
+                const metadataResponse = await fetchWithAuth(`/api/articles/${articleId}`)
                 if (metadataResponse.ok) {
                   const articleData: Article = await metadataResponse.json()
                   setArticle(articleData)
                 }
 
-                const contentResponse = await fetch(`/api/articles/${articleId}/content`)
+                const contentResponse = await fetchWithAuth(`/api/articles/${articleId}/content`)
                 if (contentResponse.ok) {
                   const contentText = await contentResponse.text()
                   setContent(contentText)
@@ -200,7 +200,7 @@ export default function ArticleDetailPage() {
             // Reload article metadata to reflect failed status
             const fetchArticle = async () => {
               try {
-                const metadataResponse = await fetch(`/api/articles/${articleId}`)
+                const metadataResponse = await fetchWithAuth(`/api/articles/${articleId}`)
                 if (metadataResponse.ok) {
                   const articleData: Article = await metadataResponse.json()
                   setArticle(articleData)

--- a/src/web/app/login/page.tsx
+++ b/src/web/app/login/page.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import Link from 'next/link'
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    // Form validation
+    if (!email || !password) {
+      setError('Email and password are required')
+      return
+    }
+
+    if (!email.includes('@')) {
+      setError('Please enter a valid email address')
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      await login(email, password)
+      // Redirect is handled by AuthContext
+    } catch (err: any) {
+      setError(err.message || 'Login failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Sign in to your account
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Or{' '}
+            <Link href="/register" className="font-medium text-blue-600 hover:text-blue-500">
+              create a new account
+            </Link>
+          </p>
+        </div>
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          {error && (
+            <div className="rounded-md bg-red-50 p-4">
+              <div className="flex">
+                <div className="ml-3">
+                  <h3 className="text-sm font-medium text-red-800">{error}</h3>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="rounded-md shadow-sm -space-y-px">
+            <div>
+              <label htmlFor="email" className="sr-only">
+                Email address
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Email address"
+                disabled={loading}
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="sr-only">
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Password"
+                disabled={loading}
+              />
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Signing in...' : 'Sign in'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/web/app/page.tsx
+++ b/src/web/app/page.tsx
@@ -5,9 +5,11 @@ import { useRouter } from 'next/navigation'
 import MarkdownViewer from '@/components/MarkdownViewer'
 import InputForm from '@/components/InputForm'
 import { fetchWithAuth } from '@/lib/api'
+import { useAuth } from '@/contexts/AuthContext'
 
 export default function Home() {
   const router = useRouter()
+  const { isAuthenticated, user, logout } = useAuth()
   const [content, setContent] = useState<string>('')
   const [loading, setLoading] = useState(false)
   const [generating, setGenerating] = useState(false)
@@ -239,6 +241,12 @@ Choose a topic you're interested in and start learning with content that matches
     length: string
     topic: string
   }, force: boolean = false) => {
+    // Check authentication
+    if (!isAuthenticated) {
+      alert('You need to log in to generate articles. Please log in first.')
+      return
+    }
+
     setGenerating(true)
     try {
       const response = await fetchWithAuth('/api/generate', {
@@ -349,21 +357,57 @@ Choose a topic you're interested in and start learning with content that matches
     )
   }
 
+  const handleArticlesClick = () => {
+    if (!isAuthenticated) {
+      alert('You need to log in to view articles. Please log in first.')
+      return
+    }
+    router.push('/articles')
+  }
+
+  const handleGenerateClick = () => {
+    setShowForm(!showForm)
+  }
+
   return (
     <main className="min-h-screen p-8 max-w-4xl mx-auto bg-white rounded-lg shadow-2xl my-8">
-      <div className="flex justify-end items-center mb-8 gap-3">
-        <button
-          onClick={() => router.push('/articles')}
-          className="bg-gray-700 text-white px-6 py-2.5 rounded-lg hover:bg-gray-600 transition-colors font-medium"
-        >
-          Articles
-        </button>
-        <button
-          onClick={() => setShowForm(!showForm)}
-          className="bg-emerald-600 text-white px-6 py-2.5 rounded-lg hover:bg-emerald-500 transition-colors font-medium"
-        >
-          {showForm ? 'Hide Form' : 'Generate New Article'}
-        </button>
+      <div className="flex justify-between items-center mb-8">
+        <div className="flex items-center gap-3">
+          {isAuthenticated ? (
+            <>
+              <span className="text-gray-700 font-medium">
+                {user?.name || user?.email}
+              </span>
+              <button
+                onClick={logout}
+                className="bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition-colors font-medium text-sm"
+              >
+                Logout
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={() => router.push('/login')}
+              className="bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+            >
+              Login
+            </button>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleArticlesClick}
+            className="bg-gray-700 text-white px-6 py-2.5 rounded-lg hover:bg-gray-600 transition-colors font-medium"
+          >
+            Articles
+          </button>
+          <button
+            onClick={handleGenerateClick}
+            className="bg-emerald-600 text-white px-6 py-2.5 rounded-lg hover:bg-emerald-500 transition-colors font-medium"
+          >
+            {showForm ? 'Hide Form' : 'Generate New Article'}
+          </button>
+        </div>
       </div>
 
       {showForm && (

--- a/src/web/app/register/page.tsx
+++ b/src/web/app/register/page.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import Link from 'next/link'
+
+export default function RegisterPage() {
+  const { register } = useAuth()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    // Form validation
+    if (!name || !email || !password || !confirmPassword) {
+      setError('All fields are required')
+      return
+    }
+
+    if (!email.includes('@')) {
+      setError('Please enter a valid email address')
+      return
+    }
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters long')
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      await register(email, password, name)
+      // Redirect is handled by AuthContext
+    } catch (err: any) {
+      setError(err.message || 'Registration failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Create your account
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Already have an account?{' '}
+            <Link href="/login" className="font-medium text-blue-600 hover:text-blue-500">
+              Sign in
+            </Link>
+          </p>
+        </div>
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          {error && (
+            <div className="rounded-md bg-red-50 p-4">
+              <div className="flex">
+                <div className="ml-3">
+                  <h3 className="text-sm font-medium text-red-800">{error}</h3>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="rounded-md shadow-sm -space-y-px">
+            <div>
+              <label htmlFor="name" className="sr-only">
+                Name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                autoComplete="name"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Full name"
+                disabled={loading}
+              />
+            </div>
+            <div>
+              <label htmlFor="email" className="sr-only">
+                Email address
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Email address"
+                disabled={loading}
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="sr-only">
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Password (min 8 characters)"
+                disabled={loading}
+              />
+            </div>
+            <div>
+              <label htmlFor="confirmPassword" className="sr-only">
+                Confirm Password
+              </label>
+              <input
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Confirm password"
+                disabled={loading}
+              />
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Creating account...' : 'Create account'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/web/contexts/AuthContext.tsx
+++ b/src/web/contexts/AuthContext.tsx
@@ -45,14 +45,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             const userData = await response.json()
             setUser(userData)
           } else {
-            // Token is invalid (expired or malformed)
+            // Token is invalid (expired or malformed) - silently clear it
             removeToken()
             setUser(null)
-
-            // Notify user only if response indicates token expiration (401)
-            if (response.status === 401) {
-              alert('Your session has expired. Please log in again.')
-            }
           }
         } catch (error) {
           console.error('Failed to verify token:', error)
@@ -84,7 +79,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const data = await response.json()
     saveToken(data.token)
     setUser(data.user)
-    router.push('/articles')
+    router.push('/')
   }
 
   const register = async (email: string, password: string, name: string) => {
@@ -104,13 +99,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const data = await response.json()
     saveToken(data.token)
     setUser(data.user)
-    router.back()
+    router.push('/')
   }
 
   const logout = () => {
     removeToken()
     setUser(null)
-    router.push('/login')
+    router.push('/')
   }
 
   return (
@@ -124,7 +119,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         loading,
       }}
     >
-      {children}
+      {loading ? (
+        <div className="min-h-screen flex items-center justify-center bg-white">
+          <div className="text-xl text-gray-900">Loading...</div>
+        </div>
+      ) : (
+        children
+      )}
     </AuthContext.Provider>
   )
 }


### PR DESCRIPTION
Add authentication UI with login and register pages

- Create /login page with email/password form validation
- Create /register page with email/password/name form validation
- Add error handling and loading states
- Integrate with AuthContext for authentication flow
- Redirect to home page after successful login/register