### PR TITLE
fix(web): repair Railway build for OpenAPI type relocation

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,8 +1,8 @@
 # Dockerfile for Web service (Next.js)
-FROM node:20-slim
+FROM node:22-slim
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Install pnpm (pinned for build reproducibility)
+RUN corepack enable && corepack prepare pnpm@10.31.0 --activate
 
 # Copy project files
 WORKDIR /app

--- a/client/libs/types/article.ts
+++ b/client/libs/types/article.ts
@@ -4,7 +4,7 @@
  * These types match the FastAPI ArticleResponse and ArticleListResponse models.
  */
 
-import type { components } from './api.generated';
+import type { components } from '../api-types/api.generated';
 
 // Wrap generated types for backward compatibility
 export type Article = components['schemas']['ArticleResponse'];

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "openapi-typescript": "^7.0.0"
   },
   "engines": {
-    "node": ">=20"
-  }
+    "node": ">=22.13"
+  },
+  "packageManager": "pnpm@10.31.0"
 }


### PR DESCRIPTION
- Update broken import path in article.ts after api.generated.ts moved to client/libs/api-types/ (root cause of unknown/components type errors in build)
- Bump Docker base to node:22-slim (pnpm 11.9.0 requires Node 22.13+ for node:sqlite builtin)
- Pin pnpm to 10.31.0 via packageManager field for build reproducibility